### PR TITLE
Fix styling in Safari

### DIFF
--- a/spec/visual/templates/index.erb
+++ b/spec/visual/templates/index.erb
@@ -1,17 +1,19 @@
 <style type="text/css">
   main {
-    padding: 15px;
     column-count: 2;
     -webkit-column-count: 2;
     -moz-column-count: 2;
+    padding: 15px;
   }
   .preview {
-    margin-bottom: 15px;
-    padding: 15px;
-    color: <%= @comment_color %>;
     border: 1px dotted;
     break-inside: avoid-column;
     -webkit-column-break-inside: avoid;
+    color: <%= @comment_color %>;
+    display: inline-block;
+    margin-bottom: 15px;
+    padding: 15px;
+    width: 100%;
   }
 </style>
 

--- a/spec/visual/templates/layout.erb
+++ b/spec/visual/templates/layout.erb
@@ -38,11 +38,6 @@
     #page-footer {
       border-top: 1px dotted
     }
-    .clearfix {
-      clear: both;
-      display: table;
-      content: "";
-    }
   </style>
 </head>
 

--- a/spec/visual/templates/lexer.erb
+++ b/spec/visual/templates/lexer.erb
@@ -1,13 +1,16 @@
 <style type="text/css">
   main {
-    float: left;
-    padding: 15px;
-    width: calc(100% - 225px);
+    display: inline-block;
+    margin-right: -300px;
+    padding: 15px 300px 15px 15px;
+    width: 100%;
   }
+
   .legend {
     padding: 15px;
     padding-left: 0;
     float: right;
+    width: 250px;
   }
 </style>
 
@@ -30,4 +33,3 @@
 <% end %>
   </pre>
 </aside>
-<div class="clearfix"></div>


### PR DESCRIPTION
This improves the styling in Safari, namely:

- the index page properly aligns the previews in the second column; and
- the lexer page uses the negative margin trick to get rid of the clearfix hack.